### PR TITLE
Add a narrow space between a country's flag and name

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -8,7 +8,7 @@
     {{- end -}}
     {{- if $page.Params.flagEmoji -}}
         {{- /* https://stackoverflow.com/a/28405917 */ -}}
-        {{- $text = printf "%s&#8288;%s" $page.Params.flagEmoji $text -}}
+        {{- $text = printf "%s&#8239;%s" $page.Params.flagEmoji $text -}}
     {{- end -}}
 {{- end -}}
 

--- a/layouts/countries/single.html
+++ b/layouts/countries/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <article class="markdown book-post">
   <h1>
-    <a href="{{ .RelPermalink }}">{{ partial "countries/title.html" . }}</a>
+    <a href="{{ .RelPermalink }}">{{ partial "countries/title.html" . | safeHTML }}</a>
   </h1>
   {{ partial "docs/post-meta" . }}
   

--- a/layouts/partials/countries/title.html
+++ b/layouts/partials/countries/title.html
@@ -14,4 +14,4 @@
   {{ $title = .File.BaseFileName | humanize | title }}
 {{ end }}
 
-{{ return (printf "%s%s" .Params.flagEmoji $title) }}
+{{ return (printf "%s&#8239;%s" .Params.flagEmoji $title) }}


### PR DESCRIPTION
Before:

<img width="149" alt="image" src="https://github.com/TheStalwart/tldrtravel.info/assets/715595/1b377c6c-88e1-44dc-b5b6-fe6346ed29c6">

<img width="728" alt="image" src="https://github.com/TheStalwart/tldrtravel.info/assets/715595/6ab2d600-ee15-43a6-8301-a817b8a1283d">

After:

<img width="161" alt="image" src="https://github.com/TheStalwart/tldrtravel.info/assets/715595/3b1ca3cf-3020-4759-830f-217b3a4b318f">

<img width="728" alt="image" src="https://github.com/TheStalwart/tldrtravel.info/assets/715595/ba6b9e3c-c52f-47fb-8f7d-9401fd0e418f">
